### PR TITLE
Some test fixes for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -U tox>=1.8 coveralls
+  - pip install -U setuptools tox>=1.8 coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from djangocms_helper.base_test import BaseTransactionTestCase
+from djangocms_helper.base_test import BaseTestCase
 
 
-class BaseTest(BaseTransactionTestCase):
+class BaseTest(BaseTestCase):
     """
     Base class with utility function
     """


### PR DESCRIPTION
Test failures was reported on python 3.4 due to the use of transaction test case and setuptools version in tox