### PR TITLE
Remove docs build from tox / gh actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11.x"]
-        toxenv: [ruff, isort, black, pypi-description, docs, towncrier]
+        toxenv: [ruff, isort, black, pypi-description, towncrier]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/changes/56.bugfix
+++ b/changes/56.bugfix
@@ -1,0 +1,1 @@
+Remove docs build from tox / gh actions

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     black
     blacken
-    docs
     isort
     isort_format
     ruff


### PR DESCRIPTION
# Description

Remove docs build from tox / gh actions

## References

Fix #56 

# Checklist

* [x] Code lint checked via `inv lint`
* [ ] Tests added
